### PR TITLE
Increase contrast for toasts

### DIFF
--- a/themes/dracula/dracula-theme.css
+++ b/themes/dracula/dracula-theme.css
@@ -2449,11 +2449,11 @@ a.badge-dark:focus,a.badge-dark.focus {
 }
 
 .toast-container .toast-header {
-    color: var(--foreground);
+    color: var(--background);
 }
 
 .toast-container .toast-header .close,.toast-container .toast-header .expand-error-button {
-    color: var(--foreground);
+    color: var(--background);
     text-shadow: none
 }
 


### PR DESCRIPTION
Text was very hart to read due to low contrast. Changed text to --background and now it passes contrast checks.